### PR TITLE
Check for duplicates before storing news articles

### DIFF
--- a/__mocks__/testSetup.js
+++ b/__mocks__/testSetup.js
@@ -1,4 +1,15 @@
 jest.mock('axios')
+jest.mock('mongoose', () => {
+    const mocked = jest.createMockFromModule('mongoose')
+    return {
+        ...mocked,
+        model: jest.fn().mockImplementation(() => ({
+            createIndexes: jest.fn(),
+            create: jest.fn(),
+            find: jest.fn(),
+        })),
+    }
+})
 
 process.env.CLIENT_ID = 'testClientId'
 process.env.CLIENT_SECRET = 'testClientSecret'

--- a/src/data/testData.js
+++ b/src/data/testData.js
@@ -1,6 +1,5 @@
-const DBNews = [
+const rawNews = [
     {
-        _id: '507f191e810c19729de860ea',
         title: 'title',
         date: 'some date',
         description: 'some description',
@@ -8,7 +7,6 @@ const DBNews = [
         link: 'testLink',
     },
     {
-        _id: '3498n39g9qn59vq5vimq09fem',
         title: 'title2',
         date: 'some other date',
         description: 'a new description',
@@ -17,4 +15,15 @@ const DBNews = [
     },
 ]
 
-module.exports = { DBNews }
+const DBNews = [
+    {
+        _id: '507f191e810c19729de860ea',
+        ...rawNews[0],
+    },
+    {
+        _id: '3498n39g9qn59vq5vimq09fem',
+        ...rawNews[1],
+    },
+]
+
+module.exports = { rawNews, DBNews }

--- a/src/jobs/__tests__/cacheNews.test.js
+++ b/src/jobs/__tests__/cacheNews.test.js
@@ -3,8 +3,6 @@ const axios = require('axios')
 const News = require('../../models/News.model')
 const { rawNews } = require('../../data/testData')
 
-jest.mock('../../models/News.model')
-
 beforeEach(() => {
     jest.resetAllMocks()
     axios.get.mockResolvedValue({ data: rawNews })

--- a/src/jobs/__tests__/cacheNews.test.js
+++ b/src/jobs/__tests__/cacheNews.test.js
@@ -1,13 +1,13 @@
 const { cacheNews } = require('../cacheNews')
 const axios = require('axios')
-
 const News = require('../../models/News.model')
+const { rawNews } = require('../../data/testData')
 
 jest.mock('../../models/News.model')
 
 beforeEach(() => {
     jest.resetAllMocks()
-    axios.get.mockResolvedValue({ data: [] })
+    axios.get.mockResolvedValue({ data: rawNews })
 })
 
 afterAll(() => {
@@ -18,7 +18,7 @@ describe('cacheNews', () => {
     it('handles success', async () => {
         await cacheNews()
 
-        expect(News.create).toHaveBeenCalledTimes(1)
+        expect(News.create).toHaveBeenCalledTimes(2)
     })
     it('handles error', async () => {
         axios.get.mockRejectedValue({})

--- a/src/jobs/cacheNews.js
+++ b/src/jobs/cacheNews.js
@@ -1,17 +1,33 @@
 const News = require('../models/News.model')
 const NewsHelper = require('../utils/newsHelper')
 
+/**
+ * Fetches latest news articles,
+ * stores non-duplicates in DB.
+ */
 async function cacheNews() {
-    console.log('running [News Cache] task...')
+    console.log('[News Cache] running task...')
 
     try {
+        // Fetch the most recent 10 articles
         const news = new NewsHelper()
-        const results = await news.fetchRecentFromAPI()
+        const articles = await news.fetchRecentFromAPI()
 
-        await News.create(results)
-        console.log(new Date().toISOString(), ' [News Cache] new items stored')
+        // Create promises to save each article to DB
+        const promises = articles.map((article) => News.create(article))
+
+        // Wait out the promises
+        const results = await Promise.allSettled(promises)
+
+        // Log results
+        const newItems = results.filter((item) => item.status === 'fulfilled')
+        console.log(
+            `[News Cache] ${new Date().toISOString()} ${
+                newItems.length
+            } new items stored`
+        )
     } catch (error) {
-        console.log('error in [News Cache] task...')
+        console.log('[News Cache] error in task...')
         console.error(error)
     }
 }

--- a/src/models/News.model.js
+++ b/src/models/News.model.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose')
 
 const newsSchema = new mongoose.Schema({
-    title: String,
+    title: { type: String, unique: true, required: true },
     date: String,
     description: String,
     image: String,
@@ -9,4 +9,10 @@ const newsSchema = new mongoose.Schema({
 })
 
 const News = mongoose.model('News', newsSchema)
+
+// Ensures indexes are in place
+// Required to force UNIQUE
+// see https://stackoverflow.com/a/52395212
+News.createIndexes()
+
 module.exports = News


### PR DESCRIPTION
# Summary

resolves #20 

Please include a summary of changes

- Added unique title requirement before storing a news article in the DB. This should fix the duplicate issue.

## Type of change

Select all that apply (add an x inside brackets)

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

# Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
